### PR TITLE
A null module

### DIFF
--- a/src/main/java/io/github/protonmc/proton/base/annotation/ForceNotLoad.java
+++ b/src/main/java/io/github/protonmc/proton/base/annotation/ForceNotLoad.java
@@ -1,0 +1,15 @@
+package io.github.protonmc.proton.base.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Forces the annotation target to never be loaded as a ProtonModule.
+ * @author YTG1234
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ForceNotLoad {
+}

--- a/src/main/java/io/github/protonmc/proton/base/annotation/FromModule.java
+++ b/src/main/java/io/github/protonmc/proton/base/annotation/FromModule.java
@@ -1,6 +1,8 @@
 package io.github.protonmc.proton.base.annotation;
 
+import io.github.protonmc.proton.Proton;
 import io.github.protonmc.proton.base.module.ProtonModule;
+import net.minecraft.util.Identifier;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -15,4 +17,20 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.SOURCE)
 public @interface FromModule {
     Class<? extends ProtonModule>[] value();
+
+    /**
+     * A module used for signifying that the annotation target doesn't belong to any module.
+     * @author YTG1234
+     */
+    @ForceNotLoad
+    class NullModule extends ProtonModule {
+        public NullModule() {
+            super(Proton.identifier("null_module"));
+        }
+
+        @Override
+        public void commonInit() {
+            System.out.println("You shouldn't see this! If you're seeing this report a bug!");
+        }
+    }
 }

--- a/src/main/java/io/github/protonmc/proton/base/module/ModuleManager.java
+++ b/src/main/java/io/github/protonmc/proton/base/module/ModuleManager.java
@@ -3,6 +3,7 @@ package io.github.protonmc.proton.base.module;
 import io.github.classgraph.ClassGraph;
 import io.github.classgraph.ScanResult;
 import io.github.protonmc.proton.Proton;
+import io.github.protonmc.proton.base.annotation.ForceNotLoad;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.server.MinecraftServer;
@@ -13,16 +14,16 @@ import java.util.Map;
 
 /**
  * Manages modules.
+ *
  * @author hydos, kara-b, dzwdz, YTG1234, BoogieMonster101
  */
 public class ModuleManager {
     private static final ModuleManager INSTANCE = new ModuleManager();
+    private final Map<Class<? extends ProtonModule>, ProtonModule> modules = new HashMap<>();
 
     public static ModuleManager getInstance() {
         return INSTANCE;
     }
-
-    private final Map<Class<? extends ProtonModule>, ProtonModule> modules = new HashMap<>();
 
     /**
      * Sets up the client-side part of all modules.
@@ -36,6 +37,7 @@ public class ModuleManager {
 
     /**
      * Sets up the server start init of all modules.
+     *
      * @param server The server the modules are running on.
      */
     public void setupServerModules(MinecraftServer server) {
@@ -63,6 +65,9 @@ public class ModuleManager {
         for (String classname : classes) {
             try {
                 Class<?> clazz = Class.forName(classname);
+                // Don't load modules with the ForceNotLoad annotation applied.
+                if (clazz.isAnnotationPresent(ForceNotLoad.class)) continue;
+
                 ProtonModule protonModule = (ProtonModule) clazz.getDeclaredConstructor().newInstance();
                 this.addModule(protonModule);
                 String[] packageParts = clazz.getPackage().getName().split("\\.");
@@ -80,6 +85,7 @@ public class ModuleManager {
 
     /**
      * Adds a module to the module list.
+     *
      * @param protonModule The module to add.
      */
     public void addModule(ProtonModule protonModule) {
@@ -88,6 +94,7 @@ public class ModuleManager {
 
     /**
      * Returns the module list.
+     *
      * @return The module list as an Iterable.
      */
     public Iterable<ProtonModule> getModules() {
@@ -96,7 +103,9 @@ public class ModuleManager {
 
     /**
      * Checks if a module is enabled.
+     *
      * @param moduleClass The module to check.
+     *
      * @return If the module is enabled.
      */
     public boolean isModuleEnabled(Class<? extends ProtonModule> moduleClass) {

--- a/src/main/java/io/github/protonmc/proton/mixin/abstractblock/AbstractBlockSettingsMixin.java
+++ b/src/main/java/io/github/protonmc/proton/mixin/abstractblock/AbstractBlockSettingsMixin.java
@@ -1,5 +1,6 @@
 package io.github.protonmc.proton.mixin.abstractblock;
 
+import io.github.protonmc.proton.base.annotation.FromModule;
 import net.fabricmc.fabric.mixin.object.builder.AbstractBlockAccessor;
 import net.minecraft.block.AbstractBlock;
 import org.spongepowered.asm.mixin.Mixin;
@@ -13,6 +14,7 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 @Mixin(AbstractBlock.Settings.class)
 public class AbstractBlockSettingsMixin {
 
+    @FromModule(FromModule.NullModule.class)
     @Inject(at = @At("RETURN"), method = "copy", locals = LocalCapture.CAPTURE_FAILEXCEPTION)
     private static void copy(AbstractBlock block, CallbackInfoReturnable ci, AbstractBlock.Settings settings) {
         AbstractBlockSettingsAccessorMixin blockSettings = (AbstractBlockSettingsAccessorMixin) ((AbstractBlockAccessor)block).getSettings();


### PR DESCRIPTION
Used inside the `@FromModule` annotation to show that the target doesn't belong to any module.

As a side effect, I added the `@ForceNotLoad` annotation with causes the target to never be loaded as a `ProtonModule`.

This is a draft as I don't think it's ready yet.