### PR TITLE
Linter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'fabric-loom' version '0.5-SNAPSHOT'
 	id 'maven-publish'
 	id 'com.github.johnrengelman.shadow' version '6.0.0'
+    id "checkstyle"
 }
 
 repositories {
@@ -73,6 +74,14 @@ dependencies {
     // Generating Json at runtime
 	modImplementation "com.lettuce.fudge:artifice:${project.artifice_version}"
 	include "com.lettuce.fudge:artifice:${project.artifice_version}"
+
+    // Jitpack is temporary
+    checkstyle("com.github.ProtonMC:proton-checkstyle-checks:v1.0")
+}
+
+checkstyle {
+    toolVersion = "8.37"
+    config = rootProject.resources.text.fromFile("config/checkstyle/checkstyle.xml")
 }
 
 processResources {

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+
+<module name="Checker">
+    <property name="charset" value="UTF-8" />
+    <property name="fileExtensions" value="java"/>
+
+    <module name="TreeWalker">
+        <module name="io.github.protonmc.proton_checkstyle_checks.FromModuleCheck" />
+    </module>
+</module>

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -5,7 +5,7 @@ So you want to contribute to Proton? No problem! This guide will tell you how!
 * Use IntelliJ IDEA as your IDE, because we have an `.editorconfig` file that can tell IDEA how to format the code.
 * When using IntelliJ, ***Don't format `ResourceHandler`***!
 * Register models and loot tables using `ResourceHandler` and `DataHandler`.
-<!-- * It's recommended to add translation keys to everything you create (Although YTG1234 will do it for you if you don't). -->
+* It's recommended to add translation keys to everything you create (Although YTG1234 will do it for you if you don't).
 * When creating a new module, make sure to use the `proton` namespace in the constructor argument.
 * Annotate all Mixin method injecitons (no need to annotate fields) with the `@FromModule` annotation to specify which module the method belongs to. For example: `@FromModule(MyModule.class)`.
     * Proton has a linter that enforces this rule, so run the Gradle `check` task before you open a PR.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -5,10 +5,10 @@ So you want to contribute to Proton? No problem! This guide will tell you how!
 * Use IntelliJ IDEA as your IDE, because we have an `.editorconfig` file that can tell IDEA how to format the code.
 * When using IntelliJ, ***Don't format `ResourceHandler`***!
 * Register models and loot tables using `ResourceHandler` and `DataHandler`.
-* It's recommended to add translation keys to everything you create (Although YTG1234 will do it for you if you don't).
+<!-- * It's recommended to add translation keys to everything you create (Although YTG1234 will do it for you if you don't). -->
 * When creating a new module, make sure to use the `proton` namespace in the constructor argument.
-* Annotate all methods inside Mixin classes (no need to annotate fields) with the `@FromModule` annotation to specify which module the method belongs to. For example: `@FromModule(MyModule.class)`.
-    * In the future, Proton will have a linter that will enforce this rule.
+* Annotate all Mixin method injecitons (no need to annotate fields) with the `@FromModule` annotation to specify which module the method belongs to. For example: `@FromModule(MyModule.class)`.
+    * Proton has a linter that enforces this rule, so run the Gradle `check` task before you open a PR.
 
 ### Naming Conventions
 * For `static final` fields (constants) - use `SCREAMING_SNAKE_CASE`.

--- a/src/main/java/io/github/protonmc/proton/mixin/abstractblock/AbstractBlockSettingsMixin.java
+++ b/src/main/java/io/github/protonmc/proton/mixin/abstractblock/AbstractBlockSettingsMixin.java
@@ -1,5 +1,7 @@
 package io.github.protonmc.proton.mixin.abstractblock;
 
+import io.github.protonmc.proton.base.annotation.FromModule;
+import io.github.protonmc.proton.base.module.ProtonModule;
 import net.fabricmc.fabric.mixin.object.builder.AbstractBlockAccessor;
 import net.minecraft.block.AbstractBlock;
 import org.spongepowered.asm.mixin.Mixin;
@@ -25,6 +27,7 @@ public class AbstractBlockSettingsMixin {
     @Inject(at = @At("RETURN"),
             method = "copy(Lnet/minecraft/block/AbstractBlock;)Lnet/minecraft/block/AbstractBlock$Settings;",
             locals = LocalCapture.CAPTURE_FAILEXCEPTION)
+    @FromModule(ProtonModule.class)
     private static void copy(AbstractBlock block, CallbackInfoReturnable<AbstractBlock.Settings> cir, AbstractBlock.Settings settings) {
         AbstractBlockSettingsAccessorMixin parentSettings = (AbstractBlockSettingsAccessorMixin) ((AbstractBlockAccessor) block).getSettings();
         AbstractBlockSettingsAccessorMixin childSettings = (AbstractBlockSettingsAccessorMixin) settings;

--- a/src/main/java/io/github/protonmc/proton/mixin/client/TitleScreenMixin.java
+++ b/src/main/java/io/github/protonmc/proton/mixin/client/TitleScreenMixin.java
@@ -1,7 +1,9 @@
 package io.github.protonmc.proton.mixin.client;
 
 import com.google.common.collect.ImmutableSet;
+import io.github.protonmc.proton.base.annotation.FromModule;
 import io.github.protonmc.proton.base.client.screen.button.PButton;
+import io.github.protonmc.proton.base.module.ProtonModule;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.gui.screen.Screen;
@@ -33,6 +35,7 @@ public class TitleScreenMixin extends Screen {
      * @see TitleScreen#init()
      */
     @Inject(method = "init()V", at = @At("TAIL"))
+    @FromModule(ProtonModule.class)
     public void addPButton(CallbackInfo ci) {
         ImmutableSet<String> targets = ImmutableSet.of(I18n.translate("menu.online"));
 


### PR DESCRIPTION
I added checkstyle, with a custom checkstyle check I made for enforcing the use of `@FromModule` on Mixin methods.

For now, using `@FromModule(ProtonModule.class)` is a temporary solution until there's something else.
